### PR TITLE
Problem with saving prices if values are given comma separated

### DIFF
--- a/Classes/Hook/DataMapHooks.php
+++ b/Classes/Hook/DataMapHooks.php
@@ -320,13 +320,13 @@ class DataMapHooks
     /**
      * Centurion multiplication.
      *
-     * @param float $price Price
+     * @param string $price Price
      *
      * @return int
      */
     protected function centurionMultiplication($price)
     {
-        return intval(strval($price * 100));
+        return intval(strval(str_replace(',','.',$price) * 100));
     }
 
     /**


### PR DESCRIPTION
in case of #138 now the prices aren't given correct to database, e.g. 15,40 will be saved as 15, not as 15.40. This request fixes the issue