### PR TITLE
Order backend has no prices in articles

### DIFF
--- a/Classes/ViewHelpers/OrderEditFunc.php
+++ b/Classes/ViewHelpers/OrderEditFunc.php
@@ -92,8 +92,12 @@ class OrderEditFunc
      */
     public function sumPriceGrossFormat(array $parameter)
     {
+        $currency = 'EUR';
+        if (isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['commerce']['extConf']['defaultCurrency'])) {
+            $currency = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['commerce']['extConf']['defaultCurrency'];
+        }
         $content = '<input type="text" disabled name="' . $parameter['itemFormElName'] . '" value="' .
-            \CommerceTeam\Commerce\ViewHelpers\Money::format($parameter['itemFormElValue'] / 100, '') . '">';
+            \CommerceTeam\Commerce\ViewHelpers\Money::format(strval($parameter['itemFormElValue']), $currency) . '">';
 
         return $content;
     }


### PR DESCRIPTION
in the backend the prices inside the orders are empty. This is because the moneylib will get wrong parameters (float) and an empty currency. this merge will effect the extconf default currency and will format the prices correct in backend hook