### PR TITLE
problem with attribute and articles dividers in dca on backend, issue #140

### DIFF
--- a/Classes/Hook/DataMapHooks.php
+++ b/Classes/Hook/DataMapHooks.php
@@ -1234,13 +1234,13 @@ class DataMapHooks
 
         $record = BackendUtility::getRecord($table, $id);
 
-        $backendUser->uc['txcommerce_afterDatabaseOperations'] = 1;
+        $backendUser->uc['txcommerce_afterDatabaseOperations'] = 0;
         $backendUser->writeUC();
 
         $dynaFlexConf = \Tx_Dynaflex_Utility_TcaUtility::loadDynaFlexConfig($table, (int) $record['pid'], $record);
         $dynaFlexConf = $dynaFlexConf['DCA'];
 
-        $backendUser->uc['txcommerce_afterDatabaseOperations'] = 0;
+        $backendUser->uc['txcommerce_afterDatabaseOperations'] = 1;
         $backendUser->writeUC();
 
         if (!is_array($dynaFlexConf) || empty($dynaFlexConf)) {

--- a/Configuration/TCA/tx_commerce_products.php
+++ b/Configuration/TCA/tx_commerce_products.php
@@ -319,6 +319,29 @@ $GLOBALS['TCA']['tx_commerce_products'] = array(
             'label' => 'LLL:EXT:commerce/Resources/Private/Language/locallang_db.xml:tx_commerce_products.attributes',
             'config' => array(
                 'type' => 'flex',
+                'default' => '<T3FlexForms>
+	<data type="array">
+		<sDEF type="array">
+			<lDEF type="array">
+				<ct_1 type="array">
+					<vDEF></vDEF>
+				</ct_1>
+				<ct_2 type="array">
+					<vDEF></vDEF>
+				</ct_2>
+				<ct_3 type="array">
+					<vDEF></vDEF>
+				</ct_3>
+				<ct_4 type="array">
+					<vDEF></vDEF>
+				</ct_4>
+				<ct_5 type="array">
+					<vDEF></vDEF>
+				</ct_5>
+			</lDEF>
+		</sDEF>
+	</data>
+</T3FlexForms>',
                 'ds' => array(
                     'default' => '
 <T3DataStructure>


### PR DESCRIPTION
after two hours of debugging, I found, that those lines are affected for a correct loading of the DCA fields for products.
We figured out, that setting the default value to attributes (an empty dca config array) will resolve the problem too.
I don't know, why the function alterDCA_onLoad is called two times, but this solves the problem with the missing dividers.

As the opener wrote, it takes only effect on NEW products, not on existing.